### PR TITLE
Build dir error

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Bluetooth and (soon to be) Obex client that is straight to the point, DE/WM ag
 
 # Compiling
 - `git clone https://github.com/kaii-lb/overskride && cd overskride`
-- `mkdir -p build && cd build`
+- `meson build && cd build`
 - `meson compile && meson devenv`
 - `mkdir -p ~/.local/share/glib-2.0/schemas`
 - `cp ../data/com.kaii.Overskride.gschema.xml ~/.local/share/glib-2.0/schemas`


### PR DESCRIPTION
*Solves* the following error:
```
ERROR: Current directory is not a meson build directory: `./Downloads/overskride/build`.
Please specify a valid build dir or change the working directory to it.
It is also possible that the build directory was generated with an old
meson version. Please regenerate it in this case.
```