### PR TITLE
feat: order trusted devices below connected devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ glib-compile-schemas ~/.local/share/glib-2.0/schemas
 - Selecting between multiple adapters
 - Rename adapter 
 - Resizing support 
-- Sorting devices by rssi (signal strength)
+- Sorting devices by rssi (signal strength) (connected and then trusted devices come first)
 - Showing errors to user
 - Changing files storage location
 - Auto accept files

--- a/src/widgets/device_action_row.rs
+++ b/src/widgets/device_action_row.rs
@@ -24,6 +24,8 @@ mod imp {
         pub adapter_name: RefCell<String>,
         #[property(get, set = Self::set_current_connected)]
         pub connected: RefCell<bool>,
+        #[property(get, set)]
+        pub trusted: RefCell<bool>,
 
         pub address: RefCell<bluer::Address>,
         pub adapter_address: RefCell<bluer::Address>,


### PR DESCRIPTION
fixes #34

There's no visual indicator in the list that a device is previously trusted, but this does  preserve the ordering

Connected -> Trusted -> ___ -> Unknown device

Also took the opportunity to clean up some of the dead code in the sorting function and make it slightly more consistent